### PR TITLE
Disable debug messages from the mail.

### DIFF
--- a/pages/signin.php
+++ b/pages/signin.php
@@ -63,7 +63,7 @@ if(Input::exists()){
 								
 								$mail = new PHPMailer;
 								$mail->IsSMTP(); 
-								$mail->SMTPDebug = 2;
+								$mail->SMTPDebug = 0;
 								$mail->Debugoutput = 'html';
 								$mail->Host = $GLOBALS['email']['host'];
 								$mail->Port = $GLOBALS['email']['port'];


### PR DESCRIPTION
I think the debug should be off, anybody can see the messages between the server & client when 2fa is enabled by mail. 